### PR TITLE
Disabled negative gateway tests

### DIFF
--- a/cucumber.js
+++ b/cucumber.js
@@ -8,7 +8,7 @@ const config = {
     'junit:functional-output/functional/cucumber-result.xml',
   ],
   formatOptions: { snippetInterface: 'async-await' },
-  tags: `(not @broken and not @obsolete and not @TODO and not @review) and ${process.env.INCLUDE_TAGS ? `(${process.env.INCLUDE_TAGS})` : '(@smoketest or @regression or @end2end)'}`,
+  tags: `(not @broken and not @obsolete and not @TODO and not @review and not @disabled) and ${process.env.INCLUDE_TAGS ? `(${process.env.INCLUDE_TAGS})` : '(@smoketest or @regression or @end2end)'}`,
   // retry features with @retry tag up to 2 times
   retry: 2,
   retryTagFilter: '@retry',

--- a/features/SoapApi/DARTS_AddCase.feature
+++ b/features/SoapApi/DARTS_AddCase.feature
@@ -184,7 +184,7 @@ Feature: AddCase using SOAP
       """
     Then the API status code is 200
 
-  @DMP-1706
+  @DMP-1706 @disabled
   Scenario: addCase invalid court name fails
     Given I authenticate from the "VIQ" source system
     When I call POST SOAP API using soap action "addCase" and body:
@@ -212,7 +212,7 @@ Feature: AddCase using SOAP
     Then the API status code is 500
     And the SOAP fault response includes "Courthouse Not Found"
 
-  @DMP-1706
+  @DMP-1706 @disabled
   Scenario: addCase access from XHIBIT fails
     Given I authenticate from the "XHIBIT" source system
     When I call POST SOAP API using soap action "addCase" and body:

--- a/features/SoapApi/DARTS_AddCourtlog.feature
+++ b/features/SoapApi/DARTS_AddCourtlog.feature
@@ -95,7 +95,7 @@ Feature: Add Courtlog SOAP
       """
     Then the API status code is 200
 
-  @regression
+  @regression @disabled
   Scenario: addLogEntry with invalid court fails
     Given I authenticate from the "VIQ" source system
     When I call POST SOAP API using soap action "addLogEntry" and body:
@@ -115,7 +115,7 @@ Feature: Add Courtlog SOAP
     Then the API status code is 500
     And the SOAP fault response includes "Courthouse Not Found"
 
-  @regression
+  @regression @disabled
   Scenario: addLogEntry with authenticating from XHIBIT fails
     Given I authenticate from the "XHIBIT" source system
     When I call POST SOAP API using soap action "addLogEntry" and body:

--- a/features/SoapApi/DARTS_DailyList.feature
+++ b/features/SoapApi/DARTS_DailyList.feature
@@ -90,7 +90,7 @@ Feature: Add Daily List using SOAP
       | XHIBIT | 58b211f5-426d-81be-00{{seq}}00 | DL    | DL      | DL {{date+0/}} {{seq}}00 | HARROW CROWN COURT | 1         | T{{seq}}101 | {{date+0}} | 10:00:00  | {{date+0}} | {{timestamp}} | T{{seq}}101 defendant |
       | CPP    | 58b211f5-426d-81be-00{{seq}}01 | CPPDL | DL      | DL {{date+0/}} {{seq}}01 | HARROW CROWN COURT | 1         | T{{seq}}111 | {{date+0}} | 10:00:00  | {{date+0}} | {{timestamp}} | T{{seq}}111 defendant |
 
-  @DMP-2968 @regression
+  @DMP-2968 @regression @disabled
   Scenario: Daily List VIQ User fails
     Given I authenticate from the "VIQ" source system
     When I call POST SOAP API using soap action "addDocument" and body:
@@ -182,7 +182,7 @@ Feature: Add Daily List using SOAP
       """
     Then the API status code is 500
 
-  @DMP-2968 @regression
+  @DMP-2968 @regression @disabled
   Scenario: Daily List malformed fails
     Given I authenticate from the "VIQ" source system
     When I call POST SOAP API using soap action "addDocument" and body:

--- a/features/SoapApi/DARTS_Events.feature
+++ b/features/SoapApi/DARTS_Events.feature
@@ -780,7 +780,7 @@ Feature: Test operation of SOAP events
       """
     Then the API status code is 200
 
-  @EVENT_API @SOAP_API @DMP-2960 @regression
+  @EVENT_API @SOAP_API @DMP-2960 @regression @disabled
   Scenario: Verify that VIQ cannot create an event
     Given I authenticate from the "VIQ" source system
     When I call POST SOAP API using soap action "addDocument" and body:
@@ -869,7 +869,7 @@ Feature: Test operation of SOAP events
     Then the API status code is 200
     And I see table "EVENT" column "count(eve.eve_id)" is "1" where "cas.case_number" = "T{{seq}}400  " and "courthouse_name" = "HARROW CROWN COURT"
 
-  @EVENT_API @SOAP_API @DMP-2960 @regression
+  @EVENT_API @SOAP_API @DMP-2960 @regression @disabled
   Scenario: Verify that event creation for an invalid courthouse fails
     Given I authenticate from the "XHIBIT" source system
     When I call POST SOAP API using soap action "addDocument" and body:
@@ -891,7 +891,7 @@ Feature: Test operation of SOAP events
     Then the API status code is 500
     And the SOAP fault response includes "Courthouse Not Found"
 
-  @EVENT_API @SOAP_API @DMP-2960 @regression
+  @EVENT_API @SOAP_API @DMP-2960 @regression @disabled
   Scenario: Create an event using invalid type / subtype
     Given I authenticate from the "XHIBIT" source system
     When I call POST SOAP API using soap action "addDocument" and body:

--- a/features/SoapApi/DARTS_GetCases.feature
+++ b/features/SoapApi/DARTS_GetCases.feature
@@ -25,6 +25,7 @@ Feature: GetCases using SOAP
       """
     Then the API status code is 200
 
+  @disabled
   Scenario: getCases invalid court name fails
     Given I authenticate from the "VIQ" source system
     When I call POST SOAP API using soap body:
@@ -39,6 +40,7 @@ Feature: GetCases using SOAP
     Then the API status code is 500
     And the SOAP fault response includes "Courthouse Not Found"
 
+  @disabled
   Scenario: getCases authentication from XHIBIT fails
     Given I authenticate from the "XHIBIT" source system
     When I call POST SOAP API using soap body:

--- a/features/SoapApi/DARTS_RegisterNode.feature
+++ b/features/SoapApi/DARTS_RegisterNode.feature
@@ -41,6 +41,7 @@ Feature: REGISTER NODE using SOAP
       """
     Then the API status code is 200
 
+  @disabled
   Scenario Outline: SOAP registerNode invalid courthouse
     Given I authenticate from the "VIQ" source system
     When I call POST SOAP API using soap action "registerNode" and body:
@@ -60,6 +61,7 @@ Feature: REGISTER NODE using SOAP
     Then the API status code is 500
     And the SOAP fault response includes "Courthouse Not Found"
 
+  @disabled
   Scenario Outline: SOAP registerNode cannot be accessed from XHIBIT
     Given I authenticate from the "XHIBIT" source system
     When I call POST SOAP API using soap action "registerNode" and body:

--- a/features/portalAdmin/DARTS_Admin_Transcripts.feature
+++ b/features/portalAdmin/DARTS_Admin_Transcripts.feature
@@ -624,6 +624,17 @@ Feature: Admin portal transcripts
     And I click on the "Advanced search" link
     And I set "Case ID" to "G{{seq}}004"
     And I press the "Search" button
+
+    When I press the "Hide or delete" button
+    And I select the "Public interest immunity" radio button
+    And I set "Enter ticket reference" to "12345"
+    And I set "Comments" to "Hiding to test unhide button"
+    And I press the "Hide or delete" button
+    Then I see "Files successfully hidden or marked for deletion" on the page
+    And I press the "Continue" button
+    And I press the "Unmark for deletion and unhide" button
+    Then I do not see "Hiding to test unhide button" on the page
+
     And I press the "Hide or delete" button
     And I select the "Public interest immunity" radio button
     And I set "Enter ticket reference" to "{{seq}}"


### PR DESCRIPTION
### Jira link

See [DMP-4794](https://tools.hmcts.net/jira/browse/PROJ-DMP-4794)

### Change description

- Added disabled tag in cucumber.js.
- Disabled negative gateway tests to allow for log monitoring activity.
- Added a few lines to DMP-4239 scenario (Delete transcript functionality for admin users) to cover unhide button.

### Testing done

N/A

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
