### PR TITLE
Extend timeout for ms sign out and text lookup

### DIFF
--- a/src/page-objects/base.ts
+++ b/src/page-objects/base.ts
@@ -22,17 +22,23 @@ export class BasePage {
   }
 
   async containsText(text: string, visible = true) {
+    const timeout = this.getTimeoutForText(text);
+  
     if (!visible) {
       await expect(this.page.getByText(text).nth(0)).toBeVisible({
         visible: false,
-        timeout: 10000,
+        timeout,
       });
     } else {
       const allMatchingLocators = this.page.getByText(text);
       const visibleLocators = allMatchingLocators.locator('visible=true');
       const firstVisibleItem1 = visibleLocators.first();
-      await expect(firstVisibleItem1).toBeVisible();
+      await expect(firstVisibleItem1).toBeVisible({ timeout});
     }
+  }
+
+  private getTimeoutForText(text: string): number {
+    return text === 'Sign in to the DARTS Portal' ? 15000 : 10000;
   }
 
   async clickLabel(text: string, exact: boolean = false) {


### PR DESCRIPTION
Increased timeout await to account for app logout due to dependency on MS sign out time, and increased default timeout for text lookups.